### PR TITLE
Guard against empty table

### DIFF
--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -80,6 +80,10 @@ function Pomodoro.stop()
 end
 
 function Pomodoro.setup(tbl)
+    if tbl == nil or #tbl == 0 then
+      return
+    end
+
     if tbl.time_work then
         vim.g.pomodoro_time_work = tbl.time_work
     end


### PR DESCRIPTION
Allow user to just use `require("pomodoro").setup()` for default values

Without this patch, there's this error:
`packer.nvim: Error running config for pomodoro.nvim: ...im/site/pack/packer/start/pomodoro.nvim/lua/pomodoro.lua:83: attempt to index local 'tbl' (a nil value)
`