### PR TITLE
Better guard for empty table.

### DIFF
--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -80,7 +80,7 @@ function Pomodoro.stop()
 end
 
 function Pomodoro.setup(tbl)
-    if tbl == nil or #tbl == 0 then
+    if tbl == nil or next(tbl) == nil then
       return
     end
 


### PR DESCRIPTION
#tbl only works if the keys in the table are ints. 

<img width="1838" alt="image" src="https://github.com/wthollingsworth/pomodoro.nvim/assets/1205776/d3cf1069-b213-412b-8c70-1b1e58e3fcac">

fixes #8 

