### PR TITLE
Fix broken icons and add customization options (#7)

### DIFF
--- a/lua/pomodoro.lua
+++ b/lua/pomodoro.lua
@@ -2,6 +2,9 @@ vim.g.pomodoro_time_work = 25
 vim.g.pomodoro_time_break_short = 5
 vim.g.pomodoro_time_break_long = 20
 vim.g.pomodoro_timers_to_long_break = 4
+vim.g.pomodoro_stopped_icon = ' (inactive)' -- nf-fa-stop | f04d
+vim.g.pomodoro_started_icon = ' ' -- nf-md-timer_sand_complete | f199f 
+vim.g.pomodoro_break_icon = ' ' -- nf-fa-coffee | f0f4
 
 local pomodoro_state = 'stopped'
 local pomodoro_work_started_at = 0
@@ -57,14 +60,14 @@ function Pomodoro.start()
 end
 
 function Pomodoro.statusline()
-    if pomodoro_state == 'stopped' then
-        return 'ﮫ (inactive)'
-    elseif pomodoro_state == 'started' then
-        return '羽' .. pomodoro_time_remaining(vim.g.pomodoro_time_work, pomodoro_work_started_at)
-    else
-        local break_minutes = pomodoro_time_break()
-        return 'ﲊ ' .. pomodoro_time_remaining(break_minutes, pomodoro_break_started_at)
-    end
+  if pomodoro_state == 'stopped' then
+      return vim.g.pomodoro_stopped_icon
+  elseif pomodoro_state == 'started' then
+      return vim.g.pomodoro_started_icon .. pomodoro_time_remaining(vim.g.pomodoro_time_work, pomodoro_work_started_at)
+  else
+      local break_minutes = pomodoro_time_break()
+      return vim.g.pomodoro_break_icon .. pomodoro_time_remaining(break_minutes, pomodoro_break_started_at)
+  end
 end
 
 function Pomodoro.status()
@@ -98,6 +101,18 @@ function Pomodoro.setup(tbl)
 
     if tbl.timers_to_long_break then
         vim.g.pomodoro_timers_to_long_break = tbl.timers_to_long_break
+    end
+
+    if tbl.stopped_icon then
+      vim.g.pomodoro_stopped_icon = tbl.stopped_icon
+    end
+
+    if tbl.started_icon then
+      vim.g.pomodoro_started_icon = tbl.started_icon
+    end
+
+    if tbl.break_icon then
+      vim.g.pomodoro_break_icon = tbl.break_icon
     end
 end
 


### PR DESCRIPTION
Fix broken icons and add customization options (#7)

This PR addresses issue #7 by implementing the following changes:

- Replaced broken icons with working Nerd Font icons for different Pomodoro states.
- Added global variables to allow customization of icons for 'stopped', 'started', and 'break' states.
- Updated setup function to support icon customization.

This change fixes the icon display issue and provides flexibility for users to customize the Pomodoro icons as requested in the issue. This should also address the concerns mentioned using nvim without patched fonts.
